### PR TITLE
Update key entry for longer API keys in HeLO

### DIFF
--- a/cogs/apikeys.py
+++ b/cogs/apikeys.py
@@ -13,7 +13,7 @@ from discord_utils import CallableButton, get_success_embed, get_error_embed, Cu
 SECURITY_URL = "https://github.com/timraay/HLLLogUtilities/blob/main/SECURITY.md"
 
 class HSSApiKeysModal(Modal):
-    key = ui.TextInput(label="API Key", required=True, min_length=45, max_length=55)
+    key = ui.TextInput(label="API Key", required=True, min_length=45, max_length=120)
 
     def __init__(self, callback, *, title: str = ..., timeout: Optional[float] = None, **kwargs) -> None:
         super().__init__(title=title, timeout=timeout, **kwargs)

--- a/lib/hss/api.py
+++ b/lib/hss/api.py
@@ -79,13 +79,13 @@ class HSSApi:
                                 headers={'Authorization': f'Bearer {key}'}) as resp:
                 if resp.status != http.HTTPStatus.OK:
                     raise HTTPException(resp.status, 'Could not load teams. Expected 200 OK response, got: ' + str(resp.status))
-                
+
                 body = await resp.json()
                 
                 tag = body.get('tag')
                 if tag is None:
                     raise HTTPException(resp.status, 'Received invalid data. Body does not include tag.')
-                
+
                 return HSSTeam(
                     tag=tag,
                     name=body.get('name'),

--- a/lib/storage.py
+++ b/lib/storage.py
@@ -6,7 +6,7 @@ import logging
 
 from lib.info.models import *
 
-DB_VERSION = 5
+DB_VERSION = 6
 HLU_VERSION = "v2.2.8"
 
 class LogLine(BaseModel):
@@ -266,7 +266,7 @@ elif db_version < DB_VERSION:
         cursor.execute(str(Query.drop_table("sessions")))
         cursor.execute('ALTER TABLE "sessions_new" RENAME TO "sessions";')
 
-    if db_version < 5:
+    if db_version < 6:
         # Create a new table with the proper columns
         table_name = 'hss_api_keys'
         table_name_new = f'{table_name}_new'

--- a/lib/storage.py
+++ b/lib/storage.py
@@ -157,7 +157,7 @@ cursor.execute("""
 CREATE TABLE IF NOT EXISTS "hss_api_keys" (
 	"guild_id"	VARCHAR(18) NOT NULL,
 	"tag"	VARCHAR(10) NOT NULL,
-	"key"	VARCHAR(55)
+	"key"	VARCHAR(120)
 );
 """)
 cursor.execute("""
@@ -265,6 +265,28 @@ elif db_version < DB_VERSION:
         cursor.execute('INSERT INTO "sessions_new" SELECT * FROM "sessions";')
         cursor.execute(str(Query.drop_table("sessions")))
         cursor.execute('ALTER TABLE "sessions_new" RENAME TO "sessions";')
+
+    if db_version < 5:
+        # Create a new table with the proper columns
+        table_name = 'hss_api_keys'
+        table_name_new = f'{table_name}_new'
+        cursor.execute(f"""
+            CREATE TABLE IF NOT EXISTS "{table_name_new}" (
+                "guild_id"	VARCHAR(18) NOT NULL,
+                "tag"	VARCHAR(10) NOT NULL,
+                "key"	VARCHAR(120)
+            );
+            """)
+        # Copy over the values
+        to_copy = ['guild_id', 'tag', 'key']
+        query = Query.into(table_name_new).columns(*to_copy).from_(table_name).select(*to_copy)
+        cursor.execute(str(query))
+        # Drop the old table
+        cursor.execute(str(Query.drop_table(table_name)))
+        # Rename the new table
+        cursor.execute(f'ALTER TABLE "{table_name_new}" RENAME TO "{table_name}";')
+
+        database.commit()
 
 
     cursor.execute('UPDATE "db_version" SET "format_version" = ?', (DB_VERSION,))


### PR DESCRIPTION
API Keys in HeLO can be longer depending on the length of the Tag of the team. E.g. Greyhounds use multiple non-ANSI chars that needs to be encoded in the hssb format, which makes the token longer than 55 chars. Update the key field to be able to hold up to 120 chars (just to be on the safe side)..