### PR TITLE
Update Dockerfile to include sqlite inside

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM python:3.8-alpine
 
+RUN apk add --no-cache sqlite sqlite-dev
+
 WORKDIR /code
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 COPY ./ .
+
+RUN sqlite3 /code/sessions.db "VACUUM;"
 
 ENTRYPOINT [ "python", "/code/bot.py" ]


### PR DESCRIPTION
modify Dockerfile by including `sqlite` into docker image, so no need to install it on a host machine and create volume link to sessions.db

only one thing - we should create a file on a host machine before building a container. just put in console in current directory

`touch sessions.db`

it creates an empty file so when container created it will update it with a command `sqlite3 sessions.db "VACUUM;"` inside a container