### PR TITLE
Fix punishing correct squad when using panther

### DIFF
--- a/lib/rcon/models.py
+++ b/lib/rcon/models.py
@@ -396,7 +396,7 @@ class Squad(TeamModelMixin, BaseModel):
 
     def get_players(self) -> Generator['Player', Any, None]:
         for player in self.snapshot.players:
-            if player.squad_id == self.id and player.team_id == self.id:
+            if player.squad_id == self.id and player.team_id == self.team_id:
                 yield player
 
     def get_leader(self) -> 'Player | None':


### PR DESCRIPTION
When iterating players from a squad, the team needs to be evaluated against the team ID of that squad, not the squad ID.

Right now, the wrong players would've been punished (when the tank quad using the panther is either Able (1) or Baker (2)). In that case, the Able/Baker players of the possibly opposite squad would've been punished. In most cases, simply no punish would occur.

Reported by: @eXactDevFlaw